### PR TITLE
シェーダーをリファクタリング

### DIFF
--- a/script/RoundedRect.hlsl
+++ b/script/RoundedRect.hlsl
@@ -3,7 +3,6 @@ cbuffer constant0 : register(b0) {
     float4 lineColor;
     float4 radius; // LT, RT, RB, LB
     float4 lineOuterRadius;
-    float4 lineInnerRadius;
     float2 halfSize; // width, height
     float2 halfRectSize;
     float lineW;
@@ -26,13 +25,7 @@ float sdRoundRect(float2 p, float2 b, float4 r) {
 // アルファブレンド
 // src: 前景色, dst: 背景色
 float4 blend(float4 src, float4 dst) {
-    float alpha = src.a + dst.a * (1.0 - src.a);
-    if (alpha < 1e-6) {
-        return float4(0.0, 0.0, 0.0, 0.0);
-    } else {
-        float4 color = src + (1 - src.a) * dst;
-        return float4(color.rgb, alpha);
-    }
+    return src + (1 - src.a) * dst;
 }
 
 // ピクセルシェーダーのメイン関数
@@ -47,7 +40,7 @@ float4 psmain(PSInput input) : SV_Target {
 
     // ライン(ストローク)
     float d2 = sdRoundRect(p, halfSize, lineOuterRadius);
-    float d3 = sdRoundRect(p, halfSize - lineW, lineInnerRadius);
+    float d3 = d2 + lineW;
     float alpha2 = (abs(d2) < abs(d3)) ? saturate(0.5 - d2) : saturate(0.5 + d3);
     alpha2 *= (lineW > 0.0) ? lineColor.a : 0.0;
     float4 lineCol = float4(lineColor.rgb * alpha2, alpha2);

--- a/script/角丸四角形KR.obj2
+++ b/script/角丸四角形KR.obj2
@@ -127,25 +127,13 @@ local function expand(x)
     return res
 end
 
-local function shrink(x)
-    local res = {}
-    for i = 1, #radius do
-        res[i] = math.max(0, radius[i] - x)
-    end
-    return res
-end
-
 local lineOuterRadius = {}
-local lineInnerRadius = {}
 if linePos == 0 then
     lineOuterRadius = radius
-    lineInnerRadius = shrink(lineW)
 elseif linePos == 1 then
     lineOuterRadius = expand(lineW / 2)
-    lineInnerRadius = shrink(lineW / 2)
 elseif linePos == 2 then
     lineOuterRadius = expand(lineW)
-    lineInnerRadius = radius
 end
 
 -- 描画
@@ -161,8 +149,6 @@ obj.pixelshader(
         radius[1], radius[2], radius[3], radius[4],
         -- lineOuterRadius
         lineOuterRadius[1], lineOuterRadius[2], lineOuterRadius[3], lineOuterRadius[4],
-        -- lineInnerRadius
-        lineInnerRadius[1], lineInnerRadius[2], lineInnerRadius[3], lineInnerRadius[4],
         -- halfSize
         imageW / 2, imageH / 2,
         -- halfRectSize


### PR DESCRIPTION
- アルファブレンドの式にまだ無駄が残っていたので修正
- d3の値はSDFを使わなくてもd2から求められたので修正